### PR TITLE
Add address shift

### DIFF
--- a/i2c/i2c.c
+++ b/i2c/i2c.c
@@ -153,7 +153,7 @@ uint8_t i2c_start(uint8_t address, uint8_t mode)
   if ( (twst != TW_START) && (twst != TW_REP_START)) return twst;
 
   /* Send device address */
-  TWDR = address | mode;
+  TWDR = (address << 1) | mode;
   TWCR = _BV(TWINT) | _BV(TWEN);
 
   /* Wait until transmission completed and ACK/NACK has been received */


### PR DESCRIPTION
Hello,

I was working with the I2C portion of your library with QEmu and found something I wanted to make you aware of. 

I believe the address passed to the `i2c_start` routine should be shifted by one bit to the left. Since I2C addresses are the upper 7 bits of a byte, the 0th bit being a R/W, most I2C libraries will shift the address passed to the routine like this for the user, so the value passed in correctly shows up in the upper 7 bits of the byte that is sent. 

Hope that makes sense, let me know if you have any questions. 

Sam

